### PR TITLE
不使用項目に空文字が入っていたら他の文字で置き換える

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -3,14 +3,15 @@ package internal
 import (
 	"bufio"
 	"errors"
-	"github.com/Kyash/zengin-go/types"
-	"golang.org/x/net/html/charset"
-	"golang.org/x/text/encoding/japanese"
-	"golang.org/x/text/transform"
 	"io"
 	"log"
 	"strconv"
 	"time"
+
+	"github.com/Kyash/zengin-go/types"
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
 )
 
 type Reader interface {
@@ -76,8 +77,8 @@ func parseAccountType(accountType string) (types.AccountType, error) {
 	}
 }
 
-func parseNewCode(accountType string) (types.NewCode, error) {
-	switch accountType {
+func parseNewCode(newCode string) (types.NewCode, error) {
+	switch newCode {
 	case "1":
 		return types.CodeFirstTransfer, nil
 	case "2":
@@ -85,7 +86,7 @@ func parseNewCode(accountType string) (types.NewCode, error) {
 	case "0":
 		return types.CodeOther, nil
 	default:
-		return types.CodeUndefined, errors.New("invalid account type: " + accountType)
+		return types.CodeUndefined, errors.New("invalid new code: " + newCode)
 	}
 }
 

--- a/internal/parsers.go
+++ b/internal/parsers.go
@@ -3,9 +3,10 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"github.com/Kyash/zengin-go/types"
 	"log"
 	"strconv"
+
+	"github.com/Kyash/zengin-go/types"
 )
 
 type ParseState int
@@ -242,7 +243,11 @@ func parseData(line []rune) (types.Data, error) {
 	}
 	data.Amount = amount
 
-	newCode, err := parseNewCode(string(line[90:91])) // unused
+	rawNewCode := string(line[90:91])
+	if rawNewCode == " " {
+		rawNewCode = "0"
+	}
+	newCode, err := parseNewCode(rawNewCode)
 	if err != nil {
 		return types.Data{}, err
 	}
@@ -256,6 +261,9 @@ func parseData(line []rune) (types.Data, error) {
 
 	if len(line) >= 112 {
 		data.TransferCategory = string(line[111:112]) // unused
+		if data.TransferCategory == " " {
+			data.TransferCategory = "0"
+		}
 		if _, err := strconv.Atoi(data.TransferCategory); err != nil {
 			return types.Data{}, errors.New("invalid transfer category: contains non-numeric characters")
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -45,6 +45,5 @@ const (
 	CodeFirstTransfer  NewCode = 1 // 第 1 回振込分
 	CodeUpdateTransfer         = 2 // 変更分(被仕向銀行・支店、預金種目・口座番号)    //
 	CodeOther                  = 0
-	CodeEmpty                  = ' '
 	CodeUndefined              = -1
 )

--- a/types/types.go
+++ b/types/types.go
@@ -45,5 +45,6 @@ const (
 	CodeFirstTransfer  NewCode = 1 // 第 1 回振込分
 	CodeUpdateTransfer         = 2 // 変更分(被仕向銀行・支店、預金種目・口座番号)    //
 	CodeOther                  = 0
+	CodeEmpty                  = ' '
 	CodeUndefined              = -1
 )


### PR DESCRIPTION
# やったこと
[こちら](https://kyash-jp.slack.com/archives/C438JL04F/p1744102892286979?thread_ts=1743395768.012179&cid=C438JL04F)で問い合わせのあった全銀フォーマットのファイルがアップロードできない問題に対応

新規コードと持ち込み区分の２項目
どちらも項目として存在しているものの未使用のため、数字で埋めることに動作上の問題はない
![スクリーンショット 2025-04-08 21 44 41](https://github.com/user-attachments/assets/7bb1e396-918c-41fb-b6db-fb39930a7f72)

# エラー
## エラー1
新規コード
```
go run main.go ~/Downloads/振込データ_振込No.00000385_20250408.txt 

2025/04/08 18:16:31 error parsing data record: invalid account type:  
exit status 1
```

## エラー2
持込区分
```
go run main.go ~/Downloads/振込データ_振込No.00000385_20250408.txt

2025/04/08 18:31:01 error parsing data record: invalid transfer category: contains non-numeric characters
exit status 1
```