### PR TITLE
Revert Go 1.24 upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kyash/zengin-go
 
-go 1.24.6
+go 1.20
 
 require (
 	golang.org/x/net v0.19.0


### PR DESCRIPTION
## Summary
- Revert the Go 1.24 upgrade merge commit from main branch

## Reason
Reverting the Go version upgrade to address compatibility issues.

## Changes
- Reverts commit 689f74e (Merge pull request #14 from Kyash/fix/go-1.24-upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)